### PR TITLE
updated to version v1.1.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,4 +12,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/paritytech/get-fellows-action/action:1.1.0'
+  image: 'docker://ghcr.io/paritytech/get-fellows-action/action:1.1.1'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-fellows-action",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Fetch all the GitHub handles from the Fellows",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
As per [the docs](https://github.com/paritytech/get-fellows-action?tab=readme-ov-file#deployment), unless we update those two files, the new version will not be deployed as a Docker package.

Required to have #20's change.

Also, we need this to be merged before polkadot-fellows/runtimes#265, else it will not work as the package doesn't currently exist.